### PR TITLE
Fix reverse() in 'yield from' and '__iter__'

### DIFF
--- a/docs/notes/python-generator.rst
+++ b/docs/notes/python-generator.rst
@@ -553,7 +553,7 @@ profile code block
     ...         while True:
     ...             yield n
     ...             n += 1
-    ...     def __reversed(self):
+    ...     def __reversed__(self):
     ...         n = 9527
     ...         while True:
     ...            yield n 


### PR DESCRIPTION
The method is called `__reversed__` not `__reversed`