### PR TITLE
Typo fix in 'Decorator with arguments'

### DIFF
--- a/docs/notes/python-basic.rst
+++ b/docs/notes/python-basic.rst
@@ -716,7 +716,7 @@ Decorator with arguments
     >>> def decorator_with_argument(val):
     ...   def decorator(func):
     ...     @wraps(func)
-    ...     def wrapper(*args, **kargs):
+    ...     def wrapper(*args, **kwargs):
     ...       print "Val is {0}".format(val)
     ...       return func(*args, **kwargs)
     ...     return wrapper


### PR DESCRIPTION
The keyword argument in wrapper function is named **kargs, but the function inside wrapper function takes **kwargs. So I changed the wrapper function argument to **kwargs.