### PR TITLE
Typo on "Match hex color value" section

### DIFF
--- a/docs/notes/python-rexp.rst
+++ b/docs/notes/python-rexp.rst
@@ -227,11 +227,10 @@ Match hex color value
 
 .. code-block:: python
 
-    <_sre.SRE_Match object at 0x10886f288>
     >>> re.match('^#?([a-f0-9]{6}|[a-f0-9]{3})$', '#ffffff')
     <_sre.SRE_Match object at 0x10886f6c0>
     >>> re.match('^#?([a-f0-9]{6}|[a-f0-9]{3})$', '#fffffh')
-    >>>
+    <_sre.SRE_Match object at 0x10886f288>
 
 
 Match email


### PR DESCRIPTION
Fixed this issue: 
![wrong](https://user-images.githubusercontent.com/11994719/29570370-9617306a-8756-11e7-99b9-5db470a770a7.png)
