### PR TITLE
Make delegate() pass its argument to fib()

### DIFF
--- a/docs/notes/python-new-py3.rst
+++ b/docs/notes/python-new-py3.rst
@@ -463,7 +463,7 @@ Generator delegation
     ...         b, a = a + b, b
     ...
     >>> def delegate(n: int):
-    ...     yield from fib(10)
+    ...     yield from fib(n)
     ...
     >>> list(delegate(10))
     [0, 1, 1, 2, 3, 5, 8, 13, 21, 34]


### PR DESCRIPTION
Fixes #41 

Tested code, works just as well for arguments up to 10, and even better for arguments > 10.