### PR TITLE
Add dual-stack address parsing snippet

### DIFF
--- a/docs/notes/python-socket.rst
+++ b/docs/notes/python-socket.rst
@@ -20,6 +20,53 @@ Get Hostname
     >>> socket.gethostbyname('localhost')
     '127.0.0.1'
 
+Get address family and socket address from string
+-------------------------------------------------
+
+.. code-block:: python
+
+    import socket
+    import sys
+
+
+    try:
+        for res in socket.getaddrinfo(sys.argv[1], None,
+                                      proto=socket.IPPROTO_TCP):
+            family = res[0]
+            sockaddr = res[4]
+            print(family, sockaddr)
+    except socket.gaierror:
+        print("Invalid")
+
+Output:
+
+.. code-block:: console
+
+    $ gai.py 192.0.2.244
+    AddressFamily.AF_INET ('192.0.2.244', 0)
+    $ gai.py 2001:db8:f00d::1:d
+    AddressFamily.AF_INET6 ('2001:db8:f00d::1:d', 0, 0, 0)
+    $ gai.py www.google.com
+    AddressFamily.AF_INET6 ('2607:f8b0:4006:818::2004', 0, 0, 0)
+    AddressFamily.AF_INET ('172.217.10.132', 0)
+
+It handles unusual cases, valid and invalid:
+
+.. code-block:: console
+
+    $ gai.py 10.0.0.256  # octet overflow
+    Invalid
+    $ gai.py not-exist.example.com  # unresolvable
+    Invalid
+    $ gai.py fe80::1%eth0  # scoped
+    AddressFamily.AF_INET6 ('fe80::1%eth0', 0, 0, 2)
+    $ gai.py ::ffff:192.0.2.128  # IPv4-Mapped
+    AddressFamily.AF_INET6 ('::ffff:192.0.2.128', 0, 0, 0)
+    $ gai.py 0xc000027b  # IPv4 in hex
+    AddressFamily.AF_INET ('192.0.2.123', 0)
+    $ gai.py 3221226198  # IPv4 in decimal
+    AddressFamily.AF_INET ('192.0.2.214', 0)
+
 Transform Host & Network Endian
 --------------------------------
 


### PR DESCRIPTION
This snippet demonstrates a simple yet powerful application of the `getaddrinfo` protocol when used to parse a string that may contain an IPv4 address, an IPv6 address, or a hostname. The result is the address family and a sockaddr object.