### PR TITLE
Surround a binary operator with a single space

### DIFF
--- a/docs/notes/python-set.rst
+++ b/docs/notes/python-set.rst
@@ -90,7 +90,7 @@ b contains a
 
     >>> a = set([1, 2])
     >>> b = set([1, 2, 5, 6])
-    >>> a <=b
+    >>> a <= b
     True
 
 a contains b


### PR DESCRIPTION
* Surround a binary operator with a single space

[PEP8 Reference - Other Recommendations](https://www.python.org/dev/peps/pep-0008/#id28)

> Always surround these binary operators with a single space on either side: assignment (=), augmented assignment (+=, -= etc.), comparisons (==, <, >, !=, <>, <=, >=, in, not in, is, is not), Booleans (and, or, not).