### PR TITLE
remove async keyword 

### DIFF
--- a/docs/notes/python-asyncio.rst
+++ b/docs/notes/python-asyncio.rst
@@ -411,7 +411,7 @@ Asynchronous Iterator
     >>> class AsyncIter:
     ...     def __init__(self, it):
     ...         self._it = iter(it)
-    ...     async def __aiter__(self):
+    ...     def __aiter__(self):
     ...         return self
     ...     async def __anext__(self):
     ...         await asyncio.sleep(1)
@@ -441,7 +441,7 @@ What is asynchronous iterator
     >>> class AsyncIter:
     ...     def __init__(self, it):
     ...         self._it = iter(it)
-    ...     async def __aiter__(self):
+    ...     def __aiter__(self):
     ...         return self
     ...     async def __anext__(self):
     ...         await asyncio.sleep(1)


### PR DESCRIPTION
In python's version equal 3.7，the original code cause  TypeError: 'async for' received an object from __aiter__ that does not implement __anext__: coroutine.
so remove this keyword，it is all right.
doc: https://www.python.org/dev/peps/pep-0492/#new-coroutine-declaration-syntax


Signed-off-by: bzd111 <zxc@gogogozxc.xyz>