### PR TITLE
docs: fix simple typo, weired -> weird

### DIFF
--- a/docs/notes/python-basic.rst
+++ b/docs/notes/python-basic.rst
@@ -148,7 +148,7 @@ such as list or tuple at the same time, using ``enumerate`` is better than
 for ... else ...
 ----------------
 
-It may be a little weired when we see the ``else`` belongs to a ``for`` loop at
+It may be a little weird when we see the ``else`` belongs to a ``for`` loop at
 the first time. The ``else`` clause can assist us to avoid using flag
 variables in loops. A loop’s ``else`` clause runs when no break occurs.
 


### PR DESCRIPTION
There is a small typo in docs/notes/python-basic.rst.

Should read `weird` rather than `weired`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md